### PR TITLE
동정복 인식모델 수정 (계급장 인식, 리턴값)

### DIFF
--- a/AI_BE/OZEngine/dress_checkers/FullDressUniformChecker.py
+++ b/AI_BE/OZEngine/dress_checkers/FullDressUniformChecker.py
@@ -87,23 +87,26 @@ class FullDressUniformChecker():
     def getClasses(self, masked_img, contours, hierarchy):
         h, w = masked_img.shape[:2]
         res_contour, res_content = None, None
-        for contour in contours:
+        for contour in contours:  # contours : 계급장이라 판별되는 contour
             if cv2.contourArea(contour) > 300:
                 center_p = getContourCenterPosition(contour)
                 if center_p[0] < (w//2) and not res_content:
-                    roi = masked_img[y1:y2, x1:x2]
+                    x, y, w, h = cv2.boundingRect(contour)
+                    roi = masked_img[y:y+h, x:x+w]
 
-                    small_contours, small_masked_img[name] = self.getMaskedContours(
-                        img=roi, kind=name, sort=False)
+                    small_contours, small_mask = self.getMaskedContours(
+                        img=roi, kind='classes', sort=False)
 
                     classes_n = 0
                     for small_contour in small_contours:
                         if 10 < cv2.contourArea(small_contour):
                             classes_n += 1
+                            cv2.drawContours(
+                                small_mask, [small_contour], 0, Color.BLUE, 1)
 
                     if 1 <= classes_n <= 4:
                         res_contour, res_content = contour, Classes.dic[classes_n]
-        return res_contour, res_content
+        return res_contour, res_content, small_mask
 
     def getAnchor(self, contours, hierarchy):
         res_contour, res_content = None, None
@@ -151,7 +154,7 @@ class FullDressUniformChecker():
         name = 'classes'
         contours, masked_img[name] = self.getMaskedContours(
             img=img, hsv_img=hsv_img, kind=name, sort=False)
-        contour_dic[name], component_dic[name] = self.getClasses(
+        contour_dic[name], component_dic[name], masked_img['classes_roi'] = self.getClasses(
             img, contours, None)
 
         # 마후라 체크

--- a/AI_BE/OZEngine/dress_checkers/FullDressUniformChecker.py
+++ b/AI_BE/OZEngine/dress_checkers/FullDressUniformChecker.py
@@ -51,7 +51,7 @@ class FullDressUniformChecker():
         for i, (contour, lev) in enumerate(zip(contours, hierarchy)):
             cur_node, next_node, prev_node, first_child, parent = lev
             if i == 0:  # 정복
-                shirt_contour = None
+                shirt_contour = contour
                 shirt_node = cur_node
                 continue
 
@@ -121,10 +121,10 @@ class FullDressUniformChecker():
         component_dic = {}
         masked_img = {}
 
-        # 정복 filter
-        name = 'uniform'
+        # 이름표 체크
+        name = 'name'
         contours, sorted_hierarchy, masked_img[name] = self.getMaskedContours(
-            img=img, hsv_img=hsv_img, kind=name, sort=True)
+            img=img, hsv_img=hsv_img, kind='uniform', sort=True)
         contour_dic['shirt'], contour_dic[name], component_dic[name] = self.getName(
             img, contours, sorted_hierarchy)
 

--- a/AI_BE/OZEngine/dress_checkers/FullDressUniformChecker.py
+++ b/AI_BE/OZEngine/dress_checkers/FullDressUniformChecker.py
@@ -34,11 +34,12 @@ class FullDressUniformChecker():
 
         if morph == 'erode':
             kernel = np.ones((3, 3), np.uint8)
-            mask = cv2.erode(mask, kernel, iterations=2)
-            k = cv2.getStructuringElement(cv2.MORPH_RECT, (5, 5))
-            mask2 = cv2.morphologyEx(mask, cv2.MORPH_OPEN, k)
+            org_mask = mask.copy()
 
-            plt_imshow(['maskk', 'm2'], [mask, mask2])
+            k = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (10, 2))
+            mask = cv2.erode(org_mask, k, iterations=2)
+
+            plt_imshow(['org_mask', 'maskk', 'm2'], [org_mask, mask])
 
         masked_img = cv2.bitwise_and(img, img, mask=mask)
 

--- a/AI_BE/OZEngine/dress_checkers/FullDressUniformChecker.py
+++ b/AI_BE/OZEngine/dress_checkers/FullDressUniformChecker.py
@@ -18,6 +18,8 @@ class FullDressUniformChecker():
             'lower': (140, 120, 50), 'upper': (190, 255, 255)}
 
     def getMaskedContours(self, img=None, hsv_img=None, kind=None, sort=True):
+        if hsv_img is None:
+            hsv_img = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
         if kind == 'uniform':
             lower, upper = self.uniform_filter['lower'], self.uniform_filter['upper']
         elif kind == 'classes':
@@ -82,14 +84,25 @@ class FullDressUniformChecker():
                     res_contour, res_content = contour, ''.join(name_chrs)
         return shirt_contour, res_contour, res_content
 
-    def getClasses(self, img, contours, hierarchy):
-        h, w = img.shape[:2]
+    def getClasses(self, masked_img, contours, hierarchy):
+        h, w = masked_img.shape[:2]
         res_contour, res_content = None, None
         for contour in contours:
             if cv2.contourArea(contour) > 300:
                 center_p = getContourCenterPosition(contour)
                 if center_p[0] < (w//2) and not res_content:
-                    res_contour, res_content = contour, True
+                    roi = masked_img[y1:y2, x1:x2]
+
+                    small_contours, small_masked_img[name] = self.getMaskedContours(
+                        img=roi, kind=name, sort=False)
+
+                    classes_n = 0
+                    for small_contour in small_contours:
+                        if 10 < cv2.contourArea(small_contour):
+                            classes_n += 1
+
+                    if 1 <= classes_n <= 4:
+                        res_contour, res_content = contour, Classes.dic[classes_n]
         return res_contour, res_content
 
     def getAnchor(self, contours, hierarchy):

--- a/AI_BE/OZEngine/dress_checkers/NavyServiceUniformChecker.py
+++ b/AI_BE/OZEngine/dress_checkers/NavyServiceUniformChecker.py
@@ -95,9 +95,9 @@ class NavyServiceUniformChecker():
             # 샘브레이 영영 안쪽 && 모서리가 4~5 && 크기가 {hyperParameter} 이상 => (이름표 or 계급장)
             # 이름표 또는 계급장
             if (not component_dic.get('name_tag') or not component_dic.get('class_tag')) and \
-                    parent == shirt_node and \
-                    3 <= getVertexCnt(contour) <= 10 and \
-                    cv2.contourArea(contour) > 300:
+                parent == shirt_node and \
+                3 <= getVertexCnt(contour) <= 10 and \
+                cv2.contourArea(contour) > 300:
 
                 center_p = getContourCenterPosition(contour)
 

--- a/AI_BE/OZEngine/model.py
+++ b/AI_BE/OZEngine/model.py
@@ -48,8 +48,9 @@ class OmilZomil:
 
     def detect(self, img):
         input_img = None
+
         if self.detect_person:
-            input_img, boxed_img = self.person_detector.detect(input_img)  # 사람인식
+            input_img, boxed_img = self.person_detector.detect(img)  # 사람인식
             if person_roi is None:
                 raise Exception("인식가능한 사람이 없습니다!")
         else:

--- a/AI_BE/OZEngine/model.py
+++ b/AI_BE/OZEngine/model.py
@@ -5,7 +5,7 @@ from .dress_classifier import classificate
 from .edge_detectors import HED, Morph, RCF
 from .person_detectors import PersonDetector  # haarcascade
 from .lib.defines import UniformType, Color
-from .lib.utils import plt_imshow
+from .lib.utils import plt_imshow, histNorm
 
 
 class OmilZomil:
@@ -56,6 +56,8 @@ class OmilZomil:
         else:
             input_img = img
 
+        hsv_dst, yCrCb_dst = histNorm(input_img)
+        input_img = yCrCb_dst
         # hair_segmentation(org) 머리카락인식
 
         self.kind = UniformType.dic['FULL_DRESS']

--- a/AI_BE/OZEngine/model.py
+++ b/AI_BE/OZEngine/model.py
@@ -51,7 +51,7 @@ class OmilZomil:
 
         if self.detect_person:
             input_img, boxed_img = self.person_detector.detect(img)  # 사람인식
-            if person_roi is None:
+            if input_img is None:
                 raise Exception("인식가능한 사람이 없습니다!")
         else:
             input_img = img
@@ -71,6 +71,6 @@ class OmilZomil:
             component_dic, contour_dic, masked_img = self.full_dress_uniform_checker.checkUniform(
                 input_img)
 
-        # boxed_img, roi_dic= self.contour2img(input_img, contour_dic)
+        boxed_img, roi_dic = self.contour2img(input_img, contour_dic)
 
         return component_dic, boxed_img, roi_dic, masked_img

--- a/AI_BE/OZEngine/model.py
+++ b/AI_BE/OZEngine/model.py
@@ -30,14 +30,14 @@ class OmilZomil:
         names, imgs = list(debug_img.keys()), list(debug_img.values())
         plt_imshow(names, imgs)
 
-    def contour2img(self, org_img, contour_dic):
+    def contour2img(self, org_img, box_position_dic):
         img = org_img.copy()
         roi_dic = {}
 
         # cv2.drawContours(img, [contour_dic['shirt']], 0, Color.GREEN, -1)
-        for name, contour in contour_dic.items():
-            if name != 'shirt' and contour is not None:
-                x, y, w, h = cv2.boundingRect(contour_dic[name])
+        for name, box_position in box_position_dic.items():
+            if name != 'shirt' and box_position is not None:
+                x, y, w, h = box_position
                 roi = org_img[y:y+h, x:x+w]
                 cv2.rectangle(img, (x, y), (x+w, y+h), Color.PURPLE, 5)
                 font = cv2.FONT_HERSHEY_SIMPLEX
@@ -66,13 +66,13 @@ class OmilZomil:
             self.kind = classificate(self.org)  # 복장종류인식 (전투복, 동정복, 샘당)
 
         if self.kind == UniformType.dic['NAVY_SERVICE']:
-            component_dic, contour_dic, masked_img = self.navy_service_uniform_checker.checkUniform(
+            component_dic, box_position_dic, masked_img = self.navy_service_uniform_checker.checkUniform(
                 input_img)
 
         elif self.kind == UniformType.dic['FULL_DRESS']:
-            component_dic, contour_dic, masked_img = self.full_dress_uniform_checker.checkUniform(
+            component_dic, box_position_dic, masked_img = self.full_dress_uniform_checker.checkUniform(
                 input_img)
 
-        boxed_img, roi_dic = self.contour2img(input_img, contour_dic)
+        boxed_img, roi_dic = self.contour2img(input_img, box_position_dic)
 
         return component_dic, boxed_img, roi_dic, masked_img


### PR DESCRIPTION
* 동정복은 계급장을 인식할 때 영역이 애매하게 겹치는 경우가 있음
   Morphology연산 (Erode)을 통해 영역을 침식시켜서 해결

* Front가 처리하기 편하려면 Controur 정보보다는 box position이 더 좋을 것 같다
   model이 return하는 값을 contorur에서 box_position으로 변경