### PR TITLE
deploy용 dev용 분리

### DIFF
--- a/.env.public
+++ b/.env.public
@@ -6,3 +6,4 @@ MYSQL_ROOT_PASSWORD=<your-password>
 
 WEB_PORT=<port>
 CAMERA_PORT=<port>
+

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,8 @@ DIR_PATH=`pwd`
 # 환경변수 파일 정의
 cat .env.private > .env.lock
 echo DIR_PATH="$DIR_PATH" >> .env.lock
+echo OMIL_DIR_PATH="$DIR_PATH"/omilzomil/backend >> .env.lock
+echo WEBRTC_DIR_PATH="$DIR_PATH"/webrtc/backend >> .env.lock
 
 # 기존 컨테이너 지우기
 echo [+] remove container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       dockerfile: backend.Dockerfile
     env_file: .env.lock
     volumes:
+      - ${WEBRTC_DIR_PATH:-webrtc_back}:/backend
       - webrtc_volume:/backend/src/app/static
 
     depends_on:
@@ -55,6 +56,7 @@ services:
       dockerfile: backend.Dockerfile
     env_file: .env.lock
     volumes:
+      - ${OMIL_DIR_PATH:-omil_back}:/backend
       - omil_volume:/backend/src/app/static
 
     depends_on:
@@ -64,5 +66,7 @@ services:
       - "${WEB_PORT}:80"
 
 volumes:
+  omil_back:
+  webrtc_back:
   omil_volume:
   webrtc_volume:

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,7 @@
 # 스크립트 설명: 서비스를 시작
 # 재시작시 백앤드에서 코드를 수정하면 반영이 되지만 프론트 앤드는 반영이 안되어서 build.sh부터 실행시켜줘야함
 
+DIR_PATH=`pwd`
 
 input=$1
 if [ "$input" = "--build" ]; then
@@ -21,7 +22,14 @@ if [ "$input" = "--build" ]; then
         sleep 1;
     done;
 
+elif [ "$input" = "--SERVER" ]; then
+    echo [+] run web camera
+    sudo docker-compose --env-file .env.private up web camera
+
+else
+    echo [+] run web camera
+    sudo docker-compose --env-file .env.lock up web camera
+
 fi
 
-echo [+] run web camera
-sudo docker-compose --env-file .env.lock up web camera
+

--- a/start.sh
+++ b/start.sh
@@ -22,7 +22,7 @@ if [ "$input" = "--build" ]; then
         sleep 1;
     done;
 
-elif [ "$input" = "--SERVER" ]; then
+elif [ "$input" = "--server" ]; then
     echo [+] run web camera
     sudo docker-compose --env-file .env.private up web camera
 


### PR DESCRIPTION
fastapi의 hot reload 기능을 활용하기 위한 코드 수정

dev용 으로 실행시 백앤드 코드를 docker의 bind로 컨테이너로 이동
- host의 변경사항이 실행중인 컨테이너에서도 그대로 반영되어 fastapi 의 hot reload 기능을 사용 할 수 있음

deploy용으로 실행시 volumne을 사용하여 빌드 시점의 백앤드 코드를 사용하여 배포
- 배포중 코드가 훼손이 안되도록 독립된 환경으로 분리